### PR TITLE
Add basic tests and structured logging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,17 +13,17 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Build custom env
         id: custom_env
         run: echo "TAG_NAME=$(basename ${{ github.ref }})" >> $GITHUB_ENV
 
       - name: Setup docker buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3
 
       - name: Add QEMU architectures
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v3
         with:
           platforms: arm,arm64
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,15 +5,30 @@ on:
     branches:
       - "*"
 
+
 env:
   architectures: linux/amd64,linux/arm64,linux/arm/v7
+  test_img: "test-image"
+
 
 jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Compile Tests
+        run: docker build -f test.dockerfile -t ${{ env.test_img }} .
+
+      - name: Test Modules
+        run: docker run --rm ${{ env.test_img }}
+
+
   build:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Build custom env
         id: custom_env

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,11 +36,11 @@ jobs:
 
       - name: Setup docker buildx
         id: docker_buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3
 
       - name: Add QEMU architectures
         id: docker_qemu
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v3
         with:
           platforms: arm,arm64
 

--- a/go.mod
+++ b/go.mod
@@ -8,4 +8,5 @@ require (
 	github.com/rs/zerolog v1.20.0
 	github.com/spf13/cobra v1.1.1
 	github.com/spf13/viper v1.7.1
+	github.com/stretchr/testify v1.7.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -32,6 +32,7 @@ github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
@@ -129,6 +130,7 @@ github.com/pelletier/go-toml v1.2.0 h1:T5zMGML61Wp+FlcbWjRDT7yAxhJNAiPPLOFECq181
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
@@ -169,9 +171,12 @@ github.com/spf13/viper v1.7.0/go.mod h1:8WkrPz2fc9jxqZNCJI/76HCieCp4Q8HaLFoCha5q
 github.com/spf13/viper v1.7.1 h1:pM5oEahlgWv/WnHXpgbKz7iLIxRf65tye2Ci+XFK5sk=
 github.com/spf13/viper v1.7.1/go.mod h1:8WkrPz2fc9jxqZNCJI/76HCieCp4Q8HaLFoCha5qpdg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.1.1 h1:2vfRuCMp5sSVIDSqO8oNnWJq7mPa6KVP3iPIwFBuy8A=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/stretchr/testify v1.7.1 h1:5TQK59W5E3v0r2duFAb7P95B6hEeOyEnHRa8MjYSMTY=
+github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
@@ -300,6 +305,8 @@ gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190418001031-e561f6794a2a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/postman/collationParser_test.go
+++ b/postman/collationParser_test.go
@@ -1,0 +1,27 @@
+package postman
+
+import (
+	"testing"
+
+	. "github.com/dvincenz/postman-mockserver/common"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetMocks(t *testing.T) {
+	mocks := getMocks([]respone{{
+		Name:   "Mock Test",
+		Status: "OK",
+		Code:   200,
+		Body:   `{"sample-body":true}`,
+		// OriginalRequest.Method: "GET",
+	}})
+	assert.Equal(t, map[string]Mock{
+		"": Mock{
+			Method: "",
+			Code:   200,
+			Name:   "Mock Test",
+			Body:   `{"sample-body":true}`,
+			Header: make([]Header, 0),
+		},
+	}, mocks)
+}

--- a/postman/service.go
+++ b/postman/service.go
@@ -74,6 +74,15 @@ func reloadCollectionHandler(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(200)
 }
 
+func bodyAsString(r *http.Request) string {
+	if r.Body != nil {
+		if bodyBytes, err := ioutil.ReadAll(r.Body); err == nil {
+			return string(bodyBytes)
+		}
+	}
+	return ""
+}
+
 func postmanRouter(w http.ResponseWriter, r *http.Request) {
 	enableCors(&w)
 	if HttpMethod(r.Method) == OPTIONS {
@@ -86,7 +95,8 @@ func postmanRouter(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	path := strings.ToLower(r.Method + urlDecoded)
-	log.Trace().Msg("requested path: " + path)
+	body := bodyAsString(r)
+	log.Trace().Str("path", path).Str("body", body).Msg("request")
 	if mock, ok := mocks[path]; ok {
 		w.Header().Set("Content-Type", "application/json")
 		for _, header := range mock.Header {
@@ -102,7 +112,7 @@ func postmanRouter(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprint(w, mock.Body)
 		return
 	}
-	log.Warn().Msg("Requested path not found: " + path)
+	log.Warn().Str("path", path).Msg("Requested path not found")
 	w.WriteHeader(404)
 }
 

--- a/postman/service_test.go
+++ b/postman/service_test.go
@@ -1,0 +1,58 @@
+package postman
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRouter_URLNotFound(t *testing.T) {
+	body := ""
+	recorder := httptest.NewRecorder()
+	req, err := http.NewRequest(http.MethodPost, "/test", strings.NewReader(body))
+	assert.Nil(t, err)
+	req.Header.Add("Content-Type", "application/json")
+	postmanRouter(recorder, req)
+	assert.Equal(t, http.StatusNotFound, recorder.Code)
+}
+
+func TestRouter_LogsRecordedAsJSON(t *testing.T) {
+	var logBuffer strings.Builder
+	log.Logger = log.Output(&logBuffer)
+	defer func() { log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stdout}) }()
+	loglevel := zerolog.GlobalLevel()
+	zerolog.SetGlobalLevel(zerolog.TraceLevel)
+	defer zerolog.SetGlobalLevel(loglevel)
+
+	body := `{"item": "test"}`
+	recorder := httptest.NewRecorder()
+	req, err := http.NewRequest(http.MethodPost, "/test", strings.NewReader(body))
+	assert.Nil(t, err)
+	req.Header.Add("Content-Type", "application/json")
+	postmanRouter(recorder, req)
+	assert.Equal(t, http.StatusNotFound, recorder.Code)
+	assert.Contains(t, logBuffer.String(), "request")
+	logLines := strings.Split(logBuffer.String(), "\n")
+	found := false
+	for i, line := range logLines {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		js := make(map[string]interface{})
+		err := json.Unmarshal([]byte(line), &js)
+		assert.Nilf(t, err, "log line %d should be valid json: %s", i, line)
+		if js["message"] == "request" {
+			found = true
+			assert.Equalf(t, "post/test", js["path"], "JSON %s", line)
+			assert.Equalf(t, `{"item": "test"}`, js["body"], "JSON %s", line)
+		}
+	}
+	assert.Truef(t, found, "log line should contain request: %s", logBuffer.String())
+}

--- a/test.dockerfile
+++ b/test.dockerfile
@@ -9,5 +9,5 @@ COPY go.sum .
 RUN go mod download
 
 COPY . .
-CMD ["sh", "+e", "-c", "for m in cmd common postman ; do cd /test/$m ; go test ; done"]
+CMD ["sh", "-c", "for m in cmd common postman ; do cd /test/$m ; go test ; done"]
 

--- a/test.dockerfile
+++ b/test.dockerfile
@@ -1,0 +1,13 @@
+FROM golang:alpine3.12
+
+ENV CGO_ENABLED=0
+ENV GOOS=linux
+
+WORKDIR /test
+COPY go.mod .
+COPY go.sum .
+RUN go mod download
+
+COPY . .
+CMD ["sh", "+e", "-c", "for m in cmd common postman ; do cd /test/$m ; go test ; done"]
+


### PR DESCRIPTION
This PR adds in basic unit testing with a docker container (and a separate github actions runner), as well as some structured trace logging for the default router.

The structured trace logging is useful for determining if a particular mock was called in automated tests. The basic unit tests were needed to test the trace logging changes. Tests are nowhere near comprehensive, but the infrastructure is now in place for them to run in CI.
